### PR TITLE
Automated Docker image build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -75,9 +75,9 @@ jobs:
         context: .
         push: ${{ github.ref_type == 'tag' }}
         tags: |
-          ghcr.io/${{ github.repository }}:postgresql-${{ github.ref_name }}
+          ghcr.io/${{ github.repository }}:postgres-${{ github.ref_name }}
           ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-          ghcr.io/${{ github.repository }}:postgresql 
+          ghcr.io/${{ github.repository }}:postgres
           ghcr.io/${{ github.repository }}:latest
 
     - name: Release

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,10 +3,7 @@
 
 name: Waltz Build (pg)
 
-on:
-  push:
-    tags: ['*']
-    branches: ['*']
+on: push
 
 jobs:
   build:
@@ -63,15 +60,6 @@ jobs:
       if: ${{ always() }}
       uses: scacap/action-surefire-report@v1
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: ${{ github.ref_type == 'tag' }}
-      with:
-        files: |
-          waltz-data/target/liquibase-scripts.zip
-          waltz-web/target/waltz-web.war
-          waltz-web/target/waltz-web-jar-with-dependencies.jar
-
     - name: Login to GitHub Registry
       if: ${{ github.ref_type == 'tag' }}
       uses: docker/login-action@v1
@@ -85,9 +73,18 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        push: true
+        push: ${{ github.ref_type == 'tag' }}
         tags: |
           ghcr.io/${{ github.repository }}:postgresql-${{ github.ref_name }}
           ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           ghcr.io/${{ github.repository }}:postgresql 
           ghcr.io/${{ github.repository }}:latest
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: ${{ github.ref_type == 'tag' }}
+      with:
+        files: |
+          waltz-data/target/liquibase-scripts.zip
+          waltz-web/target/waltz-web.war
+          waltz-web/target/waltz-web-jar-with-dependencies.jar

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,13 +3,16 @@
 
 name: Waltz Build (pg)
 
-on: push
-      
+on:
+  push:
+    tags: ['*']
+    branches: ['*']
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     services:
       postgres:
         image: postgres:11
@@ -55,16 +58,36 @@ jobs:
       with:
         name: liquibase-changelogs
         path: waltz-data/src/main/ddl/liquibase/
-    
+
     - name: Publish Test Report
       if: ${{ always() }}
       uses: scacap/action-surefire-report@v1
 
     - name: Release
       uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
+      if: ${{ github.ref_type == 'tag' }}
       with:
         files: |
           waltz-data/target/liquibase-scripts.zip
           waltz-web/target/waltz-web.war
           waltz-web/target/waltz-web-jar-with-dependencies.jar
+
+    - name: Login to GitHub Registry
+      if: ${{ github.ref_type == 'tag' }}
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      if: ${{ github.ref_type == 'tag' }}
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:postgresql-${{ github.ref_name }}
+          ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          ghcr.io/${{ github.repository }}:postgresql 
+          ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM tomcat:8-jre8-temurin
+
+ENV PATH="/usr/local/bin/liquibase:${PATH}" 
+
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY ./waltz-data/src/main/ddl/liquibase/*.xml /opt/waltz/liquibase/
+COPY ./waltz-web/target/waltz-web.war /usr/local/tomcat/webapps/ROOT.war
+COPY docker/waltz.properties /home/waltz/.waltz/waltz-template
+COPY waltz-web/src/main/resources/logback.example.xml /home/waltz/.waltz/waltz-logback.xml
+
+RUN useradd -ms /bin/bash waltz && \
+  mkdir -p /opt/waltz/liquibase /opt/liquibase && \
+  chown -R waltz:waltz /usr/local/tomcat /opt/waltz/liquibase /home/waltz/.waltz /opt/liquibase /home/waltz/.waltz/waltz-template && \
+  curl -sLO https://github.com/liquibase/liquibase-package-manager/releases/download/v0.1.2/lpm-0.1.2-linux.zip && \
+  curl -sLO https://github.com/liquibase/liquibase/releases/download/v4.5.0/liquibase-4.5.0.zip && \
+  apt-get update && apt-get install -y unzip postgresql-client gettext-base && \
+  unzip -qo lpm-0.1.2-linux.zip -d /usr/local/bin && \
+  unzip -qo liquibase-4.5.0.zip -d /opt/liquibase && \
+  ln -s  /opt/liquibase/liquibase /usr/local/bin/liquibase && \
+  rm -rf /var/lib/apt/lists/* lpm-0.1.2-linux.zip liquibase-4.5.0.zip && \
+  lpm update && lpm add -g postgresql
+
+EXPOSE 8080
+
+USER waltz
+
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+CMD [ "update",  "run" ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Learn more
 Getting started
  - [Building](docs/development/build.md) 
  - [Running](waltz-web/README.md)
+ - [Docker](docker/DOCKER.md)
 
 ---
 [![postgres build](https://github.com/finos/waltz/actions/workflows/maven.yml/badge.svg)](https://github.com/finos/waltz/actions)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,6 @@ services:
   postgres:
     image: postgres:11
     environment:
-      POSTGRES_USER: postgres
+      POSTGRES_USER: waltz
       POSTGRES_DB: waltz
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: waltz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+    
+services:
+  waltz:
+    image: ghcr.io/finos/waltz:latest
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:11
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: waltz
+      POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
     
 services:
   waltz:
-    image: ghcr.io/finos/waltz:latest
+    image: ghcr.io/G-Research/waltz:latest
     ports:
       - "8080:8080"
     depends_on:

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -1,0 +1,51 @@
+
+
+# Run Waltz
+
+### Pre Requisites
+
+* Docker
+* Postgres DB instance
+
+# Configuration
+
+- Container will use default values to connect Waltz to DB and try to `update` Postgres database and `run` Waltz.
+- You can change this with providing environment variables to container or as part of [docker-compose.yml](../docker-compose.yml)
+
+## Default values and actions
+ Container will execute two commands `update` and `run`. First command will `update` the database instance running `liquibase` command with default parameters for PostgreSQL instance listed below. Second command `run` will execute `catalina run` database and `run` Waltz.
+
+* `DB_HOST="postgres"`
+* `DB_PORT="5432"`
+* `DB_NAME="waltz"`
+* `DB_USER="waltz"`
+* `DB_PASSWORD="waltz"`
+* `DB_SCHEME="waltz"`
+* `WALTZ_FROM_EMAIL="help@finos.org"`
+* `WALTZ_BASE_URL="http://127.0.0.1:8080/"`
+* `CHANGELOG_FILE=_FILE="/opt/waltz/liquibase/db.changelog-master.xml"`
+
+# Running
+
+## Docker run
+
+Run waltz without updating database:
+
+    $> docker run -it ghcr.io/[OWNER]/[REPO]:postgresql run
+
+Run Waltz with updating new database:
+
+    $> docker run -it ghcr.io/[OWNER]/[REPO]:postgresql \
+      -e "DB_HOST=postgres" \
+      -e "DB_NAME=waltz" \
+      -e "DB_USER=waltz" \
+      -e "DB_PASSWORD=waltz" \
+      update run
+
+## Docker-compose
+
+To start you can use [docker-compose.yml](../docker-compose.yml) and run it with:
+
+    $> docker-compose up -d 
+
+Once container is up you can access Waltz dashboard on [http://127.0.0.1:8080/](http://127.0.0.1:8080/)

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -31,7 +31,7 @@ The default parameters are listed below:
 # Running
 
 ## Docker Compose
-To start Waltz with a Postgres instance in just one command, you can use [docker-compose.yml](../docker-compose.yml) and run it with:
+To start Waltz with a Postgres instance in just one command, you can use [docker-compose.yml](../docker-compose.yml) and run it with:man systemd.unit
 
     $> docker-compose up -d 
 
@@ -41,13 +41,24 @@ Once the container is up you can access the Waltz dashboard on [http://127.0.0.1
 
 Run waltz without updating the database:
 
-    $> docker run -it ghcr.io/finos/waltz run
+    $> docker run -p 8080:8080 -it ghcr.io/finos/waltz run
 
-Update the database and run Waltz with new parameters:
+Update the database and run Waltz with fresh database:
 
     $> docker run -it ghcr.io/finos/waltz \
-      -e "DB_HOST=existing_db" \
-      -e "DB_PORT=5544" \
+      -p 8080:8080 \
+      -e "DB_HOST=IP_or_FQDN" \
+      -e "DB_PORT=5432" \
       -e "DB_NAME=demo" \
-      -e "DB_USER=waltz" \
-      -e "DB_PASSWORD=12345" update run
+      -e "DB_USER=user" \
+      -e "DB_PASSWORD=password" update run
+
+Only run Waltz with pre-configured database:
+
+    $> docker run -it ghcr.io/finos/waltz \
+      -p 8080:8080 \
+      -e "DB_HOST=IP_or_FQDN" \
+      -e "DB_PORT=5432" \
+      -e "DB_NAME=demo" \
+      -e "DB_USER=user" \
+      -e "DB_PASSWORD=password" run

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -1,19 +1,22 @@
 
 
-# Run Waltz
+# Run Waltz as a container
 
 ### Pre Requisites
 
 * Docker
-* Postgres DB instance
+* Postgres DB instance (optional, can run in Docker instead)
 
 # Configuration
 
-- Container will use default values to connect Waltz to DB and try to `update` Postgres database and `run` Waltz.
-- You can change this with providing environment variables to container or as part of [docker-compose.yml](../docker-compose.yml)
+- The Waltz container will use default values to connect its DB.
+- By default it will try to `update` its DB and then `run` Waltz.
+- You can change this by providing environment variables to the container on the command line or as part of [docker-compose.yml](../docker-compose.yml)
 
 ## Default values and actions
- Container will execute two commands `update` and `run`. First command will `update` the database instance running `liquibase` command with default parameters for PostgreSQL instance listed below. Second command `run` will execute `catalina run` database and `run` Waltz.
+The container will execute two commands: `update` and `run`. The first command will `update` the database instance by running `liquibase` against it. The second command `run` will execute `catalina.sh run` to `run` Waltz.
+
+The default parameters are listed below:
 
 * `DB_HOST="postgres"`
 * `DB_PORT="5432"`
@@ -27,25 +30,24 @@
 
 # Running
 
-## Docker run
-
-Run waltz without updating database:
-
-    $> docker run -it ghcr.io/[OWNER]/[REPO]:postgresql run
-
-Run Waltz with updating new database:
-
-    $> docker run -it ghcr.io/[OWNER]/[REPO]:postgresql \
-      -e "DB_HOST=postgres" \
-      -e "DB_NAME=waltz" \
-      -e "DB_USER=waltz" \
-      -e "DB_PASSWORD=waltz" \
-      update run
-
-## Docker-compose
-
-To start you can use [docker-compose.yml](../docker-compose.yml) and run it with:
+## Docker Compose
+To start Waltz with a Postgres instance in just one command, you can use [docker-compose.yml](../docker-compose.yml) and run it with:
 
     $> docker-compose up -d 
 
-Once container is up you can access Waltz dashboard on [http://127.0.0.1:8080/](http://127.0.0.1:8080/)
+Once the container is up you can access the Waltz dashboard on [http://127.0.0.1:8080/](http://127.0.0.1:8080/)
+
+## Docker run
+
+Run waltz without updating the database:
+
+    $> docker run -it ghcr.io/finos/waltz run
+
+Update the database and run Waltz with new parameters:
+
+    $> docker run -it ghcr.io/finos/waltz \
+      -e "DB_HOST=existing_db" \
+      -e "DB_PORT=5544" \
+      -e "DB_NAME=demo" \
+      -e "DB_USER=waltz" \
+      -e "DB_PASSWORD=12345" update run

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -55,7 +55,7 @@ Once the container is up you can access the Waltz dashboard on [http://127.0.0.1
 
 Run waltz without updating the database:
 
-    $> docker run ghcr.io/finos/waltz \
+    $> docker run ghcr.io/G-Research/waltz \
       -p 8080:8080 \
       -e "DB_HOST=IP_or_FQDN" \
       -e "DB_PORT=5432" \
@@ -66,7 +66,7 @@ Run waltz without updating the database:
 
 Update the database and run Waltz with fresh database:
 
-    $> docker run ghcr.io/finos/waltz \
+    $> docker run ghcr.io/G-Research/waltz \
       -p 8080:8080 \
       -e "DB_HOST=IP_or_FQDN" \
       -e "DB_PORT=5432" \

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -31,9 +31,23 @@ The default parameters are listed below:
 # Running
 
 ## Docker Compose
-To start Waltz with a Postgres instance in just one command, you can use [docker-compose.yml](../docker-compose.yml) and run it with:man systemd.unit
+To start Waltz with a Postgres instance in just one command, you can use [docker-compose.yml](../docker-compose.yml) and run it with:
 
-    $> docker-compose up -d 
+    $> docker-compose up
+
+When the server starts you will see messages about registering
+endpoints and CORS services, similar to:
+
+````
+....
+waltz_1     | 16:33:53.088 [localhost-startStop-1] DEBUG o.f.w.w.e.a.StaticResourcesEndpoint - Registering static resources
+waltz_1     | 16:33:53.089 [localhost-startStop-1] INFO  org.finos.waltz.web.Main - Completed endpoint registration
+waltz_1     | 16:33:53.093 [localhost-startStop-1] INFO  org.finos.waltz.web.Main - GZIP not enabled
+waltz_1     | 16:33:53.094 [localhost-startStop-1] INFO  org.finos.waltz.web.Main - Enabled CORS
+waltz_1     | 09-Dec-2021 16:33:53.108 INFO [localhost-startStop-1] org.apache.catalina.startup.HostConfig.deployWAR Deployment of web application archive [/usr/local/tomcat/webapps/ROOT.war] has finished in [4,292] ms
+waltz_1     | 09-Dec-2021 16:33:53.110 INFO [main] org.apache.coyote.AbstractProtocol.start Starting ProtocolHandler ["http-nio-8080"]
+waltz_1     | 09-Dec-2021 16:33:53.117 INFO [main] org.apache.catalina.startup.Catalina.start Server startup in 4351 ms
+````
 
 Once the container is up you can access the Waltz dashboard on [http://127.0.0.1:8080/](http://127.0.0.1:8080/)
 
@@ -41,24 +55,23 @@ Once the container is up you can access the Waltz dashboard on [http://127.0.0.1
 
 Run waltz without updating the database:
 
-    $> docker run -p 8080:8080 -it ghcr.io/finos/waltz run
+    $> docker run ghcr.io/finos/waltz \
+      -p 8080:8080 \
+      -e "DB_HOST=IP_or_FQDN" \
+      -e "DB_PORT=5432" \
+      -e "DB_NAME=demo" \
+      -e "DB_USER=user" \
+      -e "DB_PASSWORD=password" \
+      run
 
 Update the database and run Waltz with fresh database:
 
-    $> docker run -it ghcr.io/finos/waltz \
+    $> docker run ghcr.io/finos/waltz \
       -p 8080:8080 \
       -e "DB_HOST=IP_or_FQDN" \
       -e "DB_PORT=5432" \
       -e "DB_NAME=demo" \
       -e "DB_USER=user" \
-      -e "DB_PASSWORD=password" update run
-
-Only run Waltz with pre-configured database:
-
-    $> docker run -it ghcr.io/finos/waltz \
-      -p 8080:8080 \
-      -e "DB_HOST=IP_or_FQDN" \
-      -e "DB_PORT=5432" \
-      -e "DB_NAME=demo" \
-      -e "DB_USER=user" \
-      -e "DB_PASSWORD=password" run
+      -e "DB_PASSWORD=password" \
+      update \
+      run

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Set default values for required env vars
+export DB_HOST=${DB_HOST:-"postgres"}
+export DB_PORT=${DB_PORT:-"5432"}
+export DB_NAME=${DB_NAME:-"waltz"}
+export DB_USER=${DB_USER:-"waltz"}
+export DB_PASSWORD=${DB_PASSWORD:-"waltz"}
+export DB_SCHEME=${DB_SCHEME:-"waltz"}
+export WALTZ_FROM_EMAIL=${WALTZ_FROM_EMAIL:-"help@finos.org"}
+export WALTZ_BASE_URL=${WALTZ_BASE_URL:-"http://127.0.0.1:8080/"}
+export CHANGELOG_FILE=${CHANGELOG_FILE:-"/opt/waltz/liquibase/db.changelog-master.xml"}
+
+db_action () {
+    while [[ $(pg_isready --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USER}" --dbname="${DB_NAME}") != *"accepting connections"* ]]
+    do
+        echo ">>> Database is not ready yet."
+        sleep 5s
+    done
+    echo ">>> Database is ready."
+
+    # changeLogFile must be relative path
+    liquibase --changeLogFile=../../../${CHANGELOG_FILE} --hub-mode=off --username="${DB_USER}" --password="${DB_PASSWORD}" --url=jdbc:postgresql://"${DB_HOST}":"${DB_PORT}"/"${DB_NAME}" "$1"
+    if [ $? -eq 0 ]; then
+        echo ">>> Database updated."
+    else
+        echo ">>> Database failed to update."
+        exit 1
+    fi
+}
+
+run_waltz () {
+    envsubst < /home/waltz/.waltz/waltz-template > /home/waltz/.waltz/waltz.properties
+    catalina.sh run
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        update) echo ">>> Update DB" && db_action update ;;
+        run) echo ">>> Run Waltz" && run_waltz ;;
+    esac
+    shift
+done

--- a/docker/waltz.properties
+++ b/docker/waltz.properties
@@ -1,0 +1,12 @@
+database.url=jdbc:postgresql://$DB_HOST:$DB_PORT/$DB_NAME 
+database.user=$DB_USER
+database.password=$DB_PASSWORD
+database.schema=$DB_SCHEME
+database.driver=org.postgresql.Driver
+
+jooq.dialect=POSTGRES
+
+database.pool.max=16
+
+waltz.from.email=$WALTZ_FROM_EMAIL
+waltz.base.url=$WALTZ_BASE_URL

--- a/waltz-web/README.md
+++ b/waltz-web/README.md
@@ -42,7 +42,7 @@ are available (typically on the classpath).
 ## Both
 
 When the server starts you will see messages about registering
-enpoints and CORS services, similar to:
+endpoints and CORS services, similar to:
 
 ````
 ....


### PR DESCRIPTION
**Building and dockerize Waltz** for running Waltz with PostgreSQL as a database so it can be run within any environment.
By default, the image will try to update DB and run Waltz with default parameters. 
In case you want to specify given actions and/or change DB parameters you can change docker's `CMD` with `run` or `update` and pass corresponding env variables as shown in the example below.

Image name: `ghcr.io/ljubon/waltz:latest`
Image size: `393MB`

Latest release: [link](https://github.com/ljubon/waltz/pkgs/container/waltz)

Default values and parameters with executing `update` and `run` 
```
docker run -it -d --name waltz ghcr.io/G-Research/waltz
```

Working example for this PR with only `run` Waltz, without `update` DB
```
docker run -it -d --name waltz \
        -p 8080=8080 \
        --env DB_HOST=postgres \
        --env DB_PORT=5432 \
        --env DB_NAME=waltz \
        --env DB_USER=waltz \
        --env DB_PASSWORD=waltz \
        --env DB_SCHEME=waltz \
        --env WALTZ_FROM_EMAIL=ljubonikolic@gmail.com \
        --env WALTZ_BASE_URL=http://localhost:8080 \
        ghcr.io/G-Research/waltz run
```